### PR TITLE
Fix broken links in RSS feeds by adding `/posts` to <link> and <guid> tags

### DIFF
--- a/scripts/rss.ts
+++ b/scripts/rss.ts
@@ -26,8 +26,8 @@ const rssFeed = `<?xml version="1.0" encoding="UTF-8"?>
       }</description>
       <dc:creator>${cdata("Maggie Liu")}</dc:creator>
       <pubDate>${new Date(post.data.date).toUTCString()}</pubDate>
-      <link>${BASE_URL}/${post.slug}</link>
-      <guid>${BASE_URL}/${post.slug}</guid>
+      <link>${BASE_URL}/posts/${post.slug}</link>
+      <guid>${BASE_URL}/posts/${post.slug}</guid>
       ${(post.data.tags ?? [])
         .map((tag: string) => `<category>${cdata(tag)}</category>`)
         .join("\n      ")}


### PR DESCRIPTION
I wanted to follow your blog using my RSS feed reader, but was wondering why I was getting 404s. In the future, I'd recommend adding a `url` property to your `Post` type a la [11ty](https://www.11ty.dev/docs/) so that the location of your pages are automatically updated if you change the structure of your site again. And remember, ["Cool URIs Don't Change."](https://www.w3.org/Provider/Style/URI.html) Excited to be able to follow your blog!